### PR TITLE
fix(mobile): polish nav, dashboard, and accessibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { motion, AnimatePresence } from "framer-motion";
 import { lazy, Suspense } from "react";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 const Index = lazy(() => import("./pages/Index"));
 const Login = lazy(() => import("./pages/Login"));
@@ -20,6 +21,17 @@ const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy"));
 const Privacy = lazy(() => import("./pages/Privacy"));
 const Terms = lazy(() => import("./pages/Terms"));
 const WelcomeToZync = lazy(() => import("./pages/WelcomeToZync"));
+const IndexMobile = lazy(() => import("./mobile/pages/IndexMobile"));
+const LoginMobile = lazy(() => import("./mobile/pages/LoginMobile"));
+const SignupMobile = lazy(() => import("./mobile/pages/SignupMobile"));
+const NotFoundMobile = lazy(() => import("./mobile/pages/NotFoundMobile"));
+const DashboardMobile = lazy(() => import("./mobile/pages/DashboardMobile"));
+const NewProjectMobile = lazy(() => import("./mobile/pages/NewProjectMobile"));
+const ProjectDetailsMobile = lazy(() => import("./mobile/pages/ProjectDetailsMobile"));
+const PrivacyPolicyMobile = lazy(() => import("./mobile/pages/PrivacyPolicyMobile"));
+const PrivacyMobile = lazy(() => import("./mobile/pages/PrivacyMobile"));
+const TermsMobile = lazy(() => import("./mobile/pages/TermsMobile"));
+const WelcomeToZyncMobile = lazy(() => import("./mobile/pages/WelcomeToZyncMobile"));
 import { useActivityTracker } from "./hooks/use-activity-tracker";
 import { useChatNotifications } from "./hooks/use-chat-notifications";
 import { useUserSync } from "./hooks/use-user-sync";
@@ -32,6 +44,7 @@ const AppContent = () => {
   useUserSync();
   useSyncData(); // Trigger local-first data fetch and Dexie sync on login/app load
   const location = useLocation();
+  const isMobile = useIsMobile();
 
 
   const getPageKey = (pathname: string) => {
@@ -55,33 +68,33 @@ const AppContent = () => {
         >
           <Suspense fallback={<div className="h-full w-full flex items-center justify-center text-sm text-muted-foreground">Loading…</div>}>
             <Routes location={location}>
-              <Route path="/" element={<Index />} />
-              <Route path="/login" element={<Login />} />
-              <Route path="/signup" element={<Signup />} />
-              <Route path="/welcome" element={<WelcomeToZync />} />
-              <Route path="/dashboard" element={<Dashboard />} />
-              <Route path="/dashboard/workspace" element={<Dashboard />} />
-              <Route path="/dashboard/workspace/project/:id" element={<Dashboard />} />
-              <Route path="/dashboard/projects" element={<Dashboard />} />
-              <Route path="/dashboard/calendar" element={<Dashboard />} />
-              <Route path="/dashboard/design" element={<Dashboard />} />
-              <Route path="/dashboard/tasks" element={<Dashboard />} />
-              <Route path="/dashboard/notes" element={<Dashboard />} />
-              <Route path="/dashboard/files" element={<Dashboard />} />
-              <Route path="/dashboard/activity" element={<Dashboard />} />
-              <Route path="/dashboard/people" element={<Dashboard />} />
-              <Route path="/dashboard/meet" element={<Dashboard />} />
-              <Route path="/dashboard/settings" element={<Dashboard />} />
-              <Route path="/dashboard/chat" element={<Dashboard />} />
-              <Route path="/dashboard/new-project" element={<Dashboard />} />
-              <Route path="/new-project" element={<NewProject />} />
-              <Route path="/projects/:id" element={<ProjectDetails />} />
+              <Route path="/" element={isMobile ? <IndexMobile /> : <Index />} />
+              <Route path="/login" element={isMobile ? <LoginMobile /> : <Login />} />
+              <Route path="/signup" element={isMobile ? <SignupMobile /> : <Signup />} />
+              <Route path="/welcome" element={isMobile ? <WelcomeToZyncMobile /> : <WelcomeToZync />} />
+              <Route path="/dashboard" element={isMobile ? <DashboardMobile /> : <Dashboard />} />
+              <Route path="/dashboard/workspace" element={isMobile ? <DashboardMobile /> : <Dashboard />} />
+              <Route path="/dashboard/workspace/project/:id" element={isMobile ? <DashboardMobile /> : <Dashboard />} />
+              <Route path="/dashboard/projects" element={isMobile ? <DashboardMobile /> : <Dashboard />} />
+              <Route path="/dashboard/calendar" element={isMobile ? <DashboardMobile /> : <Dashboard />} />
+              <Route path="/dashboard/design" element={isMobile ? <DashboardMobile /> : <Dashboard />} />
+              <Route path="/dashboard/tasks" element={isMobile ? <DashboardMobile /> : <Dashboard />} />
+              <Route path="/dashboard/notes" element={isMobile ? <DashboardMobile /> : <Dashboard />} />
+              <Route path="/dashboard/files" element={isMobile ? <DashboardMobile /> : <Dashboard />} />
+              <Route path="/dashboard/activity" element={isMobile ? <DashboardMobile /> : <Dashboard />} />
+              <Route path="/dashboard/people" element={isMobile ? <DashboardMobile /> : <Dashboard />} />
+              <Route path="/dashboard/meet" element={isMobile ? <DashboardMobile /> : <Dashboard />} />
+              <Route path="/dashboard/settings" element={isMobile ? <DashboardMobile /> : <Dashboard />} />
+              <Route path="/dashboard/chat" element={isMobile ? <DashboardMobile /> : <Dashboard />} />
+              <Route path="/dashboard/new-project" element={isMobile ? <DashboardMobile /> : <Dashboard />} />
+              <Route path="/new-project" element={isMobile ? <NewProjectMobile /> : <NewProject />} />
+              <Route path="/projects/:id" element={isMobile ? <ProjectDetailsMobile /> : <ProjectDetails />} />
 
-              <Route path="/privacy-policy" element={<PrivacyPolicy />} />
-              <Route path="/privacy" element={<Privacy />} />
-              <Route path="/terms" element={<Terms />} />
+              <Route path="/privacy-policy" element={isMobile ? <PrivacyPolicyMobile /> : <PrivacyPolicy />} />
+              <Route path="/privacy" element={isMobile ? <PrivacyMobile /> : <Privacy />} />
+              <Route path="/terms" element={isMobile ? <TermsMobile /> : <Terms />} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-              <Route path="*" element={<NotFound />} />
+              <Route path="*" element={isMobile ? <NotFoundMobile /> : <NotFound />} />
             </Routes>
           </Suspense>
         </motion.div>

--- a/src/components/ProfilePhotoCropper.tsx
+++ b/src/components/ProfilePhotoCropper.tsx
@@ -3,6 +3,7 @@ import Cropper, { Area } from "react-easy-crop";
 import {
     Dialog,
     DialogContent,
+    DialogDescription,
     DialogHeader,
     DialogTitle,
     DialogFooter,
@@ -143,6 +144,9 @@ const ProfilePhotoCropper: React.FC<ProfilePhotoCropperProps> = ({
             <DialogContent className="sm:max-w-[500px] p-0 gap-0 overflow-hidden">
                 <DialogHeader className="px-6 pt-6 pb-2">
                     <DialogTitle>Adjust Profile Photo</DialogTitle>
+                    <DialogDescription className="sr-only">
+                        Crop, zoom, and rotate your profile image before saving.
+                    </DialogDescription>
                 </DialogHeader>
 
                 {}

--- a/src/components/layout/MobileLayout.tsx
+++ b/src/components/layout/MobileLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Menu, Search, Plus, Home, Folder, CheckSquare, Bell, User } from 'lucide-react';
+import { Menu, Search, Plus, Home, Folder, CheckSquare, Bell, Settings } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
@@ -36,7 +36,7 @@ export const MobileLayout = ({
         { id: 'Projects', icon: Folder, label: 'Projects' },
         { id: 'Tasks', icon: CheckSquare, label: 'Tasks' },
         { id: 'Activity', icon: Bell, label: 'Activity' },
-        { id: 'Profile', icon: User, label: 'Profile' },
+        { id: 'Settings', icon: Settings, label: 'Settings' },
     ];
 
 

--- a/src/components/layout/MobileLayout.tsx
+++ b/src/components/layout/MobileLayout.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Menu, Search, Plus, Home, Folder, CheckSquare, Bell, Settings } from 'lucide-react';
+import { Menu, Search, Plus, Home, Video, CheckSquare, Bell, Settings } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Sheet, SheetContent, SheetTrigger, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { Sheet, SheetContent, SheetTrigger, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 
@@ -30,10 +30,11 @@ export const MobileLayout = ({
     onFabClick,
     rightHeaderAction
 }: MobileLayoutProps) => {
+    const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
 
     const navItems = [
         { id: 'Home', icon: Home, label: 'Home' },
-        { id: 'Projects', icon: Folder, label: 'Projects' },
+        { id: 'Meet', icon: Video, label: 'Meet' },
         { id: 'Tasks', icon: CheckSquare, label: 'Tasks' },
         { id: 'Activity', icon: Bell, label: 'Activity' },
         { id: 'Settings', icon: Settings, label: 'Settings' },
@@ -47,7 +48,7 @@ export const MobileLayout = ({
             {}
             <header className="h-14 border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 flex items-center justify-between px-4 shrink-0 z-40">
                 <div className="flex items-center gap-3">
-                    <Sheet>
+                    <Sheet open={isDrawerOpen} onOpenChange={setIsDrawerOpen}>
                         <SheetTrigger asChild>
                             <Button variant="ghost" size="icon" className="-ml-2 h-10 w-10">
                                 <Menu className="h-6 w-6" />
@@ -55,7 +56,12 @@ export const MobileLayout = ({
                             </Button>
                         </SheetTrigger>
                         <SheetContent side="left" className="w-[85%] sm:w-[350px] p-0">
-                            {}
+                            <SheetHeader className="sr-only">
+                                <SheetTitle>Navigation Menu</SheetTitle>
+                                <SheetDescription>
+                                    Open app navigation links and user account shortcuts.
+                                </SheetDescription>
+                            </SheetHeader>
                             <div className="flex flex-col h-full bg-background">
                                 {user && (
                                     <div className="p-6 border-b flex items-center gap-4 bg-muted/20">
@@ -69,7 +75,15 @@ export const MobileLayout = ({
                                         </div>
                                     </div>
                                 )}
-                                <div className="flex-1 overflow-y-auto">
+                                <div
+                                    className="flex-1 overflow-y-auto"
+                                    onClick={(event) => {
+                                        const target = event.target as HTMLElement;
+                                        if (target.closest("button, a, [data-close-drawer='true']")) {
+                                            setIsDrawerOpen(false);
+                                        }
+                                    }}
+                                >
                                     {drawerContent}
                                 </div>
                             </div>

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -4,7 +4,7 @@ import { Command as CommandPrimitive } from "cmdk";
 import { Search } from "lucide-react";
 
 import { cn } from "@/lib/utils";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -27,6 +27,12 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
+        <DialogHeader className="sr-only">
+          <DialogTitle>Command Menu</DialogTitle>
+          <DialogDescription>
+            Search and run available commands.
+          </DialogDescription>
+        </DialogHeader>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/src/components/views/ActivityLogView.tsx
+++ b/src/components/views/ActivityLogView.tsx
@@ -170,6 +170,20 @@ function secondsForLogsInRange(logs: ActivityLog[], rangeStart: Date, rangeEnd: 
     return total;
 }
 
+function formatHoursMinutes(totalMinutes: number): string {
+    const safeMinutes = Math.max(0, Math.floor(totalMinutes));
+    const hours = Math.floor(safeMinutes / 60);
+    const minutes = safeMinutes % 60;
+    return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+}
+
+function formatSecondsToHoursMinutes(totalSeconds: number): string {
+    const safeSeconds = Math.max(0, Math.floor(totalSeconds));
+    const hours = Math.floor(safeSeconds / 3600);
+    const minutes = Math.floor((safeSeconds % 3600) / 60);
+    return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+}
+
 type FeedTag = 'Commit' | 'Completed' | 'Invite' | 'Deadline' | 'Comment' | 'Session';
 
 interface FeedItem {
@@ -1233,7 +1247,7 @@ export default function ActivityLogView({
                         <div className="text-right">
                             <p className="text-[10px] text-text3 uppercase tracking-[0.15em] font-bold mb-1">Total time worked</p>
                             <h3 className="text-4xl font-bold tracking-tight text-text1">
-                                {Math.floor(totalActiveSeconds / 3600)}h {Math.floor((totalActiveSeconds % 3600) / 60)}m
+                                {formatSecondsToHoursMinutes(totalActiveSeconds)}
                             </h3>
                         </div>
                     </div>
@@ -1276,7 +1290,7 @@ export default function ActivityLogView({
                                     <p>Efficiency</p>
                                 </div>
                                 <div>
-                                    <p className="text-text1 font-bold">{Math.floor(taskStats.dailyActiveAvg / 60)}h {taskStats.dailyActiveAvg % 60}m</p>
+                                    <p className="text-text1 font-bold">{formatHoursMinutes(taskStats.dailyActiveAvg)}</p>
                                     <p>Daily Active (Avg)</p>
                                 </div>
                                 <div>

--- a/src/components/views/MobileView.tsx
+++ b/src/components/views/MobileView.tsx
@@ -16,7 +16,6 @@ import {
 } from "lucide-react";
 import { MobileLayout } from "@/components/layout/MobileLayout";
 import Workspace from "@/components/workspace/Workspace";
-import DashboardView from "./DashboardView";
 import TasksView from "./TasksView";
 import PeopleView from "./PeopleView";
 import CalendarView from "./CalendarView";
@@ -31,6 +30,7 @@ import { useToast } from "@/hooks/use-toast";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import MobileActivityLogView from "@/components/views/mobile/MobileActivityLogView";
+import MobileDashboardView from "@/components/views/mobile/MobileDashboardView";
 
 const MobileView = () => {
   const [activeTab, setActiveTab] = useState("Home");
@@ -39,6 +39,7 @@ const MobileView = () => {
   const [usersList, setUsersList] = useState<any[]>([]);
   const [activityLogs, setActivityLogs] = useState<any[]>([]);
   const [leaderTasks, setLeaderTasks] = useState<any[]>([]);
+  const [teamTasks, setTeamTasks] = useState<any[]>([]);
   const [teamSessions, setTeamSessions] = useState<any[]>([]);
   const [ownedTeams, setOwnedTeams] = useState<any[]>([]);
   const [myTeams, setMyTeams] = useState<any[]>([]);
@@ -172,6 +173,7 @@ const MobileView = () => {
           const projects = await projectsRes.json();
           if (Array.isArray(projects)) {
             const allTasks = buildActivityLogTasks(projects);
+            setTeamTasks(allTasks);
             const myTasks = filterCommitCapableTasks(allTasks, currentUser.uid);
             const receivedTasks = myTasks.filter(
               (task: any) => task.assignedBy !== currentUser.uid && task.createdBy !== currentUser.uid
@@ -268,7 +270,7 @@ const MobileView = () => {
   const renderContent = () => {
     switch (activeTab) {
       case "Home":
-        return currentUser ? <DashboardView currentUser={currentUser} /> : null;
+        return currentUser ? <MobileDashboardView currentUser={currentUser} /> : null;
       case "Projects":
         return currentUser ? (
           <div className="p-4">
@@ -286,6 +288,21 @@ const MobileView = () => {
           <MobileActivityLogView
             activityLogs={activityLogs}
             tasks={leaderTasks}
+            users={usersList}
+            teamSessions={teamSessions}
+            ownedTeams={ownedTeams}
+            myTeams={myTeams}
+            currentUserId={currentUser?.uid}
+            currentUserProfile={
+              currentUser
+                ? {
+                    displayName: currentUser.displayName || undefined,
+                    email: currentUser.email || undefined,
+                    photoURL: currentUser.photoURL || undefined,
+                  }
+                : null
+            }
+            teamTasks={teamTasks}
             elapsedTime={elapsedTime}
             onClearLogs={handleClearLogs}
             onDeleteLog={handleDeleteLog}
@@ -338,7 +355,6 @@ const MobileView = () => {
         photoURL: currentUser.photoURL ? getFullUrl(currentUser.photoURL) : undefined
       } : null}
       drawerContent={DrawerContent}
-      onFabClick={() => navigate("/new-project")}
       headerTitle={activeTab === 'Home' ? 'Dashboard' : activeTab}
     >
       {userMeError && currentUser && (

--- a/src/components/views/MobileView.tsx
+++ b/src/components/views/MobileView.tsx
@@ -12,7 +12,6 @@ import {
   FileText,
   Video,
   Settings,
-  LogOut,
   Bell
 } from "lucide-react";
 import { MobileLayout } from "@/components/layout/MobileLayout";
@@ -20,7 +19,6 @@ import Workspace from "@/components/workspace/Workspace";
 import DashboardView from "./DashboardView";
 import TasksView from "./TasksView";
 import PeopleView from "./PeopleView";
-import ActivityLogView from "./ActivityLogView";
 import CalendarView from "./CalendarView";
 import { NotesView } from "@/components/notes/NotesView";
 import MeetView from "./MeetView";
@@ -32,15 +30,20 @@ import { WifiOff, RefreshCw } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import MobileActivityLogView from "@/components/views/mobile/MobileActivityLogView";
 
 const MobileView = () => {
   const [activeTab, setActiveTab] = useState("Home");
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const { isError: userMeError, refetch: refetchMe } = useMe();
   const [usersList, setUsersList] = useState<any[]>([]);
+  const [activityLogs, setActivityLogs] = useState<any[]>([]);
+  const [leaderTasks, setLeaderTasks] = useState<any[]>([]);
+  const [teamSessions, setTeamSessions] = useState<any[]>([]);
+  const [ownedTeams, setOwnedTeams] = useState<any[]>([]);
+  const [myTeams, setMyTeams] = useState<any[]>([]);
+  const [elapsedTime, setElapsedTime] = useState("00:00:00");
+  const [sessionStartTime, setSessionStartTime] = useState<Date | null>(null);
   const navigate = useNavigate();
   const { toast } = useToast();
 
@@ -84,12 +87,168 @@ const MobileView = () => {
     navigate(`/projects/${id}`, { state: { from: '/dashboard/workspace' } });
   };
 
-  const handleSignOut = async () => {
+  const buildActivityLogTasks = (projects: any[]) => {
+    return projects.flatMap((project: any) =>
+      (project.steps || []).flatMap((step: any) =>
+        (step.tasks || []).map((task: any) => ({
+          ...task,
+          projectId: project._id || project.id,
+          projectName: project.name,
+          githubRepoName: project.githubRepoName,
+          githubRepoOwner: project.githubRepoOwner,
+          githubRepo: project.githubRepo,
+          repoIds: project.githubRepoIds,
+          projectOwnerId: project.ownerUid || project.ownerId,
+        }))
+      )
+    );
+  };
+
+  const filterCommitCapableTasks = (tasks: any[], userId: string) => {
+    return tasks.filter((task: any) => {
+      const assignedTo = task?.assignedTo;
+      const assignedUserIds = Array.isArray(task?.assignedUserIds) ? task.assignedUserIds : [];
+      const hasRepoLink = Boolean(
+        task?.githubRepoOwner ||
+          task?.githubRepoName ||
+          task?.githubRepo ||
+          (Array.isArray(task?.repoIds) && task.repoIds.length > 0)
+      );
+      const hasCommitCode = Boolean(task?.commitCode);
+
+      return hasRepoLink && hasCommitCode && (assignedTo === userId || assignedUserIds.includes(userId));
+    });
+  };
+
+  useEffect(() => {
+    const storedSession = localStorage.getItem("currentSession");
+    if (!storedSession) { return; }
     try {
-      await signOutAndClearState(auth);
-      navigate("/login");
+      const parsed = JSON.parse(storedSession);
+      if (parsed?.startTime) {
+        setSessionStartTime(new Date(parsed.startTime));
+      }
+    } catch {
+      // Ignore invalid local session payloads.
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!sessionStartTime) { return; }
+    const timer = setInterval(() => {
+      const now = new Date();
+      const diff = Math.max(0, Math.floor((now.getTime() - sessionStartTime.getTime()) / 1000));
+      const hours = Math.floor(diff / 3600).toString().padStart(2, "0");
+      const minutes = Math.floor((diff % 3600) / 60).toString().padStart(2, "0");
+      const seconds = (diff % 60).toString().padStart(2, "0");
+      setElapsedTime(`${hours}:${minutes}:${seconds}`);
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [sessionStartTime]);
+
+  useEffect(() => {
+    if (activeTab !== "Activity" || !currentUser) { return; }
+
+    let cancelled = false;
+    const fetchActivityData = async () => {
+      try {
+        const token = await currentUser.getIdToken();
+        const [sessionsRes, projectsRes, ownedTeamsRes, myTeamsRes] = await Promise.all([
+          fetch(`${API_BASE_URL}/api/sessions/${currentUser.uid}`, { headers: { Authorization: `Bearer ${token}` } }),
+          fetch(`${API_BASE_URL}/api/projects`, { headers: { Authorization: `Bearer ${token}` } }),
+          fetch(`${API_BASE_URL}/api/teams/owned`, { headers: { Authorization: `Bearer ${token}` } }),
+          fetch(`${API_BASE_URL}/api/teams/mine`, { headers: { Authorization: `Bearer ${token}` } }),
+        ]);
+
+        if (cancelled) { return; }
+
+        if (sessionsRes.ok) {
+          const logsData = await sessionsRes.json();
+          setActivityLogs(Array.isArray(logsData) ? logsData : []);
+        }
+
+        if (projectsRes.ok) {
+          const projects = await projectsRes.json();
+          if (Array.isArray(projects)) {
+            const allTasks = buildActivityLogTasks(projects);
+            const myTasks = filterCommitCapableTasks(allTasks, currentUser.uid);
+            const receivedTasks = myTasks.filter(
+              (task: any) => task.assignedBy !== currentUser.uid && task.createdBy !== currentUser.uid
+            );
+            setLeaderTasks(receivedTasks);
+          }
+        }
+
+        if (ownedTeamsRes.ok) {
+          const teams = await ownedTeamsRes.json();
+          setOwnedTeams(Array.isArray(teams) ? teams : []);
+        }
+
+        if (myTeamsRes.ok) {
+          const teams = await myTeamsRes.json();
+          setMyTeams(Array.isArray(teams) ? teams : []);
+        }
+
+        if (usersList.length > 0) {
+          const teamSessionsRes = await fetch(`${API_BASE_URL}/api/sessions/batch`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+            body: JSON.stringify({ userIds: usersList.map((user) => user.uid) }),
+          });
+          if (!cancelled && teamSessionsRes.ok) {
+            const sessions = await teamSessionsRes.json();
+            setTeamSessions(Array.isArray(sessions) ? sessions : []);
+          }
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.error("Failed to load mobile activity data:", error);
+        }
+      }
+    };
+
+    fetchActivityData();
+    const intervalId = setInterval(fetchActivityData, 30000);
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
+  }, [activeTab, currentUser, usersList]);
+
+  const handleDeleteLog = async (logId: string) => {
+    if (!currentUser) { return; }
+    try {
+      const token = await currentUser.getIdToken();
+      const response = await fetch(`${API_BASE_URL}/api/sessions/${logId}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (response.ok) {
+        setActivityLogs((prev) => prev.filter((log) => log._id !== logId));
+      } else {
+        throw new Error("Failed to delete log");
+      }
     } catch (error) {
-      console.error("Error signing out", error);
+      toast({ title: "Error", description: "Failed to delete log.", variant: "destructive" });
+    }
+  };
+
+  const handleClearLogs = async () => {
+    if (!currentUser) { return; }
+    try {
+      const token = await currentUser.getIdToken();
+      const response = await fetch(`${API_BASE_URL}/api/sessions/user/${currentUser.uid}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (response.ok) {
+        setActivityLogs([]);
+      } else {
+        throw new Error("Failed to clear logs");
+      }
+    } catch (error) {
+      toast({ title: "Error", description: "Failed to clear logs.", variant: "destructive" });
     }
   };
 
@@ -123,10 +282,15 @@ const MobileView = () => {
       case "Tasks":
         return currentUser ? <TasksView currentUser={currentUser} users={usersList} /> : null;
       case "Activity":
-        // ActivityLogView needs props. For now using placeholder or minimal props if possible.
-
-
-        return <div className="p-4 text-center text-muted-foreground">Activity Log (Coming Soon on Mobile)</div>;
+        return (
+          <MobileActivityLogView
+            activityLogs={activityLogs}
+            tasks={leaderTasks}
+            elapsedTime={elapsedTime}
+            onClearLogs={handleClearLogs}
+            onDeleteLog={handleDeleteLog}
+          />
+        );
       case "People":
 
         return <PeopleView users={usersList} userStatuses={{}} onChat={() => { }} />;
@@ -138,23 +302,6 @@ const MobileView = () => {
         return <MeetView currentUser={currentUser} usersList={usersList} userStatuses={{}} />;
       case "Settings":
         return <SettingsView />;
-      case "Profile":
-        return (
-          <div className="flex flex-col items-center p-6 space-y-6">
-            <div className="flex flex-col items-center gap-2">
-              <Avatar className="h-24 w-24">
-                <AvatarImage src={getFullUrl(currentUser?.photoURL)} />
-                <AvatarFallback>{currentUser?.displayName?.charAt(0)}</AvatarFallback>
-              </Avatar>
-              <h2 className="text-xl font-bold">{currentUser?.displayName}</h2>
-              <p className="text-muted-foreground">{currentUser?.email}</p>
-            </div>
-            <Button variant="destructive" className="w-full" onClick={handleSignOut}>
-              <LogOut className="mr-2 h-4 w-4" />
-              Sign Out
-            </Button>
-          </div>
-        );
       default:
         return null;
     }

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -549,17 +549,19 @@ export default function SettingsView() {
   };
 
   return (
-    <div className="flex-1 h-full overflow-y-auto bg-transparent p-6">
+    <div className="flex-1 h-full overflow-y-auto bg-transparent p-3 sm:p-6">
       <div className="max-w-4xl mx-auto space-y-8">
         <Tabs defaultValue="profile" className="space-y-6">
-          <TabsList className="bg-black border border-white/10">
-            <TabsTrigger value="profile">My Profile</TabsTrigger>
-            <TabsTrigger value="team">Team</TabsTrigger>
-            <TabsTrigger value="preferences">Preferences</TabsTrigger>
-            <TabsTrigger value="integrations">Integrations</TabsTrigger>
-            <TabsTrigger value="support">Support</TabsTrigger>
-            <TabsTrigger value="security">Security</TabsTrigger>
-          </TabsList>
+          <div className="w-full overflow-x-auto pb-1 scrollbar-thin">
+            <TabsList className="bg-black border border-white/10 inline-flex w-max min-w-full sm:min-w-0 whitespace-nowrap">
+              <TabsTrigger value="profile" className="shrink-0">My Profile</TabsTrigger>
+              <TabsTrigger value="team" className="shrink-0">Team</TabsTrigger>
+              <TabsTrigger value="preferences" className="shrink-0">Preferences</TabsTrigger>
+              <TabsTrigger value="integrations" className="shrink-0">Integrations</TabsTrigger>
+              <TabsTrigger value="support" className="shrink-0">Support</TabsTrigger>
+              <TabsTrigger value="security" className="shrink-0">Security</TabsTrigger>
+            </TabsList>
+          </div>
 
           {}
           <TabsContent value="profile">

--- a/src/components/views/mobile/MobileActivityLogView.tsx
+++ b/src/components/views/mobile/MobileActivityLogView.tsx
@@ -1,0 +1,123 @@
+import { formatDistanceToNow } from "date-fns";
+import { Activity, CheckCircle2, Clock3, ListTodo, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface MobileActivityLogViewProps {
+  activityLogs: any[];
+  tasks: any[];
+  elapsedTime: string;
+  onClearLogs: () => void;
+  onDeleteLog: (id: string) => void;
+}
+
+const normalizeStatus = (value: unknown) => String(value ?? "").toLowerCase().trim();
+
+const isCompleted = (task: any) => {
+  const status = normalizeStatus(task?.status);
+  return status.includes("complete") || status === "done";
+};
+
+const isInProgress = (task: any) => {
+  if (isCompleted(task)) return false;
+  const status = normalizeStatus(task?.status);
+  return status.includes("progress") || status === "active" || status === "in review";
+};
+
+const isOverdue = (task: any) => {
+  if (isCompleted(task)) return false;
+  const due = task?.dueDate || task?.deadline;
+  if (!due) return false;
+  return new Date(due).getTime() < Date.now();
+};
+
+const MobileActivityLogView = ({
+  activityLogs,
+  tasks,
+  elapsedTime,
+  onClearLogs,
+  onDeleteLog,
+}: MobileActivityLogViewProps) => {
+  const totalTasks = tasks.length;
+  const completed = tasks.filter(isCompleted).length;
+  const inProgress = tasks.filter(isInProgress).length;
+  const overdue = tasks.filter(isOverdue).length;
+
+  return (
+    <div className="p-4 space-y-4">
+      <Card className="bg-card/70">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Activity className="h-4 w-4 text-primary" />
+            Activity Summary
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-xs text-muted-foreground">Current session: {elapsedTime}</p>
+          <div className="grid grid-cols-2 gap-2">
+            <div className="rounded-lg border border-border/60 p-2">
+              <p className="text-[11px] text-muted-foreground">Total Tasks</p>
+              <p className="text-lg font-semibold">{totalTasks}</p>
+            </div>
+            <div className="rounded-lg border border-border/60 p-2">
+              <p className="text-[11px] text-muted-foreground">Completed</p>
+              <p className="text-lg font-semibold">{completed}</p>
+            </div>
+            <div className="rounded-lg border border-border/60 p-2">
+              <p className="text-[11px] text-muted-foreground">In Progress</p>
+              <p className="text-lg font-semibold">{inProgress}</p>
+            </div>
+            <div className="rounded-lg border border-border/60 p-2">
+              <p className="text-[11px] text-muted-foreground">Overdue</p>
+              <p className="text-lg font-semibold">{overdue}</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="bg-card/70">
+        <CardHeader className="pb-2 flex flex-row items-center justify-between">
+          <CardTitle className="text-base">Recent Activity</CardTitle>
+          {activityLogs.length > 0 && (
+            <Button size="sm" variant="outline" onClick={onClearLogs}>
+              Clear
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {activityLogs.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-6">No activity yet.</p>
+          ) : (
+            activityLogs.slice(0, 20).map((log) => {
+              const start = new Date(log.startTime);
+              const title = log.title || log.eventType || "Activity session";
+              return (
+                <div key={log._id} className="rounded-lg border border-border/60 p-3 flex items-start gap-2">
+                  <Clock3 className="h-4 w-4 text-primary mt-0.5" />
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium truncate">{title}</p>
+                    <p className="text-[11px] text-muted-foreground">
+                      {formatDistanceToNow(start, { addSuffix: true })}
+                    </p>
+                  </div>
+                  {log._id && (
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="h-7 w-7 text-destructive"
+                      onClick={() => onDeleteLog(log._id)}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default MobileActivityLogView;

--- a/src/components/views/mobile/MobileActivityLogView.tsx
+++ b/src/components/views/mobile/MobileActivityLogView.tsx
@@ -1,11 +1,24 @@
+import { useMemo, useState } from "react";
 import { formatDistanceToNow } from "date-fns";
-import { Activity, CheckCircle2, Clock3, ListTodo, Trash2 } from "lucide-react";
+import { Activity, Clock3, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 interface MobileActivityLogViewProps {
   activityLogs: any[];
   tasks: any[];
+  users?: any[];
+  teamSessions?: any[];
+  ownedTeams?: any[];
+  myTeams?: any[];
+  currentUserId?: string;
+  currentUserProfile?: {
+    displayName?: string;
+    email?: string;
+    photoURL?: string;
+  } | null;
+  teamTasks?: any[];
   elapsedTime: string;
   onClearLogs: () => void;
   onDeleteLog: (id: string) => void;
@@ -34,6 +47,13 @@ const isOverdue = (task: any) => {
 const MobileActivityLogView = ({
   activityLogs,
   tasks,
+  users = [],
+  teamSessions = [],
+  ownedTeams = [],
+  myTeams = [],
+  currentUserId,
+  currentUserProfile,
+  teamTasks = [],
   elapsedTime,
   onClearLogs,
   onDeleteLog,
@@ -42,6 +62,131 @@ const MobileActivityLogView = ({
   const completed = tasks.filter(isCompleted).length;
   const inProgress = tasks.filter(isInProgress).length;
   const overdue = tasks.filter(isOverdue).length;
+  const [expandedMemberId, setExpandedMemberId] = useState<string | null>(null);
+  const elapsedSeconds = (() => {
+    const [h, m, s] = elapsedTime.split(":").map((part) => Number(part) || 0);
+    return h * 3600 + m * 60 + s;
+  })();
+
+  const ownedTeamIds = new Set(
+    (Array.isArray(ownedTeams) ? ownedTeams : [])
+      .map((team: any) => String(team?.id || team?._id || team?.teamId || ""))
+      .filter(Boolean)
+  );
+
+  const fallbackOwnedFromMyTeams = (Array.isArray(myTeams) ? myTeams : []).filter((team: any) => {
+    const owner = String(team?.ownerId || team?.ownerUid || team?.leaderId || team?.createdBy || "");
+    return Boolean(owner) && owner === currentUserId;
+  });
+
+  fallbackOwnedFromMyTeams.forEach((team: any) => {
+    const id = String(team?.id || team?._id || team?.teamId || "");
+    if (id) {
+      ownedTeamIds.add(id);
+    }
+  });
+
+  const isLeader = ownedTeamIds.size > 0;
+
+  const teamMemberStats = (() => {
+    if (!isLeader) {
+      return [];
+    }
+
+    const members = new Map<string, { uid: string; displayName: string; email?: string; photoURL?: string }>();
+    const teamList = [...(ownedTeams || []), ...fallbackOwnedFromMyTeams];
+
+    teamList.forEach((team: any) => {
+      (team?.members || []).forEach((member: any) => {
+        const uid = String(typeof member === "string" ? member : member?.uid || member?.id || member?._id || "");
+        if (!uid) {
+          return;
+        }
+        const profileFromUsers = users.find((user: any) => user.uid === uid);
+        members.set(uid, {
+          uid,
+          displayName:
+            profileFromUsers?.displayName ||
+            (typeof member === "object" ? member?.displayName || member?.name : "") ||
+            uid,
+          email: profileFromUsers?.email || (typeof member === "object" ? member?.email : undefined),
+          photoURL: profileFromUsers?.photoURL || (typeof member === "object" ? member?.photoURL : undefined),
+        });
+      });
+    });
+
+    users.forEach((user: any) => {
+      const memberships = Array.isArray(user?.teamMemberships) ? user.teamMemberships.map(String) : [];
+      if (memberships.some((teamId: string) => ownedTeamIds.has(teamId))) {
+        members.set(user.uid, {
+          uid: user.uid,
+          displayName: user.displayName || user.email?.split("@")[0] || user.uid,
+          email: user.email,
+          photoURL: user.photoURL,
+        });
+      }
+    });
+
+    const totals = new Map<string, number>();
+    (teamSessions || []).forEach((session: any) => {
+      const uid = String(session?.userId || "");
+      if (!uid || !members.has(uid)) {
+        return;
+      }
+      const secs = Number(session?.activeDuration || 0);
+      totals.set(uid, (totals.get(uid) || 0) + secs);
+    });
+
+    if (currentUserId && members.has(currentUserId)) {
+      totals.set(currentUserId, (totals.get(currentUserId) || 0) + elapsedSeconds);
+    }
+
+    return Array.from(members.values())
+      .map((member) => ({
+        ...member,
+        activeSeconds: totals.get(member.uid) || 0,
+      }))
+      .sort((a, b) => b.activeSeconds - a.activeSeconds);
+  })();
+
+  const toTimeLabel = (totalSeconds: number) => {
+    const safe = Math.max(0, totalSeconds);
+    const hours = Math.floor(safe / 3600);
+    const minutes = Math.floor((safe % 3600) / 60);
+    return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+  };
+
+  const memberTaskStats = useMemo(() => {
+    const statsMap = new Map<string, { total: number; completed: number; inProgress: number; overdue: number }>();
+
+    (Array.isArray(teamTasks) ? teamTasks : []).forEach((task: any) => {
+      const assignees = new Set<string>();
+      if (task?.assignedTo) {
+        assignees.add(String(task.assignedTo));
+      }
+      if (Array.isArray(task?.assignedUserIds)) {
+        task.assignedUserIds.forEach((uid: any) => assignees.add(String(uid)));
+      }
+      if (assignees.size === 0) {
+        return;
+      }
+
+      assignees.forEach((uid) => {
+        const current = statsMap.get(uid) || { total: 0, completed: 0, inProgress: 0, overdue: 0 };
+        current.total += 1;
+        if (isCompleted(task)) {
+          current.completed += 1;
+        } else if (isInProgress(task)) {
+          current.inProgress += 1;
+        } else if (isOverdue(task)) {
+          current.overdue += 1;
+        }
+        statsMap.set(uid, current);
+      });
+    });
+
+    return statsMap;
+  }, [teamTasks]);
 
   return (
     <div className="p-4 space-y-4">
@@ -53,6 +198,22 @@ const MobileActivityLogView = ({
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
+          <div className="rounded-lg border border-border/60 p-2.5 flex items-center gap-2.5">
+            <Avatar className="h-9 w-9">
+              <AvatarImage src={currentUserProfile?.photoURL} />
+              <AvatarFallback>
+                {currentUserProfile?.displayName?.charAt(0)?.toUpperCase() || "U"}
+              </AvatarFallback>
+            </Avatar>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium truncate">
+                {currentUserProfile?.displayName || "Your Profile"}
+              </p>
+              <p className="text-[11px] text-muted-foreground truncate">
+                {currentUserProfile?.email || currentUserId || ""}
+              </p>
+            </div>
+          </div>
           <p className="text-xs text-muted-foreground">Current session: {elapsedTime}</p>
           <div className="grid grid-cols-2 gap-2">
             <div className="rounded-lg border border-border/60 p-2">
@@ -75,6 +236,75 @@ const MobileActivityLogView = ({
         </CardContent>
       </Card>
 
+      {isLeader && (
+        <Card className="bg-card/70">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Team Member Activity</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {teamMemberStats.length === 0 ? (
+              <p className="text-sm text-muted-foreground text-center py-4">
+                No team activity found yet.
+              </p>
+            ) : (
+              teamMemberStats.slice(0, 12).map((member) => {
+                const memberLabel = member.uid === currentUserId ? "You" : member.displayName;
+                const stats = memberTaskStats.get(member.uid) || {
+                  total: 0,
+                  completed: 0,
+                  inProgress: 0,
+                  overdue: 0,
+                };
+                const isExpanded = expandedMemberId === member.uid;
+
+                return (
+                  <div key={`member-${member.uid}`} className="space-y-1.5">
+                    <button
+                      type="button"
+                      className="w-full rounded-lg border border-border/60 p-2.5 flex items-center gap-2.5 text-left"
+                      onClick={() => setExpandedMemberId((prev) => (prev === member.uid ? null : member.uid))}
+                    >
+                      <Avatar className="h-8 w-8">
+                        <AvatarImage src={member.photoURL} />
+                        <AvatarFallback>{member.displayName?.charAt(0)?.toUpperCase() || "U"}</AvatarFallback>
+                      </Avatar>
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-medium truncate">{memberLabel}</p>
+                        <p className="text-[11px] text-muted-foreground truncate">
+                          {member.email || member.uid}
+                        </p>
+                      </div>
+                      <p className="text-sm font-semibold">{toTimeLabel(member.activeSeconds)}</p>
+                    </button>
+
+                    {isExpanded && (
+                      <div className="rounded-lg border border-border/60 p-2.5 grid grid-cols-2 gap-2 animate-in slide-in-from-top-1 duration-200">
+                        <div className="rounded-md border border-border/50 px-2 py-1.5">
+                          <p className="text-[10px] text-muted-foreground">Total Tasks</p>
+                          <p className="text-sm font-semibold">{stats.total}</p>
+                        </div>
+                        <div className="rounded-md border border-border/50 px-2 py-1.5">
+                          <p className="text-[10px] text-muted-foreground">Completed</p>
+                          <p className="text-sm font-semibold">{stats.completed}</p>
+                        </div>
+                        <div className="rounded-md border border-border/50 px-2 py-1.5">
+                          <p className="text-[10px] text-muted-foreground">In Progress</p>
+                          <p className="text-sm font-semibold">{stats.inProgress}</p>
+                        </div>
+                        <div className="rounded-md border border-border/50 px-2 py-1.5">
+                          <p className="text-[10px] text-muted-foreground">Overdue</p>
+                          <p className="text-sm font-semibold">{stats.overdue}</p>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                );
+              })
+            )}
+          </CardContent>
+        </Card>
+      )}
+
       <Card className="bg-card/70">
         <CardHeader className="pb-2 flex flex-row items-center justify-between">
           <CardTitle className="text-base">Recent Activity</CardTitle>
@@ -88,11 +318,14 @@ const MobileActivityLogView = ({
           {activityLogs.length === 0 ? (
             <p className="text-sm text-muted-foreground text-center py-6">No activity yet.</p>
           ) : (
-            activityLogs.slice(0, 20).map((log) => {
+            activityLogs.slice(0, 20).map((log, index) => {
               const start = new Date(log.startTime);
               const title = log.title || log.eventType || "Activity session";
+              const logKey =
+                log._id ||
+                `${log.startTime || "no-start"}-${log.eventType || title}-${log.userId || "no-user"}-${index}`;
               return (
-                <div key={log._id} className="rounded-lg border border-border/60 p-3 flex items-start gap-2">
+                <div key={logKey} className="rounded-lg border border-border/60 p-3 flex items-start gap-2">
                   <Clock3 className="h-4 w-4 text-primary mt-0.5" />
                   <div className="min-w-0 flex-1">
                     <p className="text-sm font-medium truncate">{title}</p>

--- a/src/components/views/mobile/MobileDashboardView.tsx
+++ b/src/components/views/mobile/MobileDashboardView.tsx
@@ -1,0 +1,135 @@
+import { eachDayOfInterval, formatISO } from "date-fns";
+import { Github, Users, GitFork } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  ContributionGraph,
+  ContributionGraphBlock,
+  ContributionGraphCalendar,
+  ContributionGraphLegend,
+  ContributionGraphTotalCount,
+} from "@/components/kibo-ui/contribution-graph";
+import { useGitHubStats, useGitHubContributions } from "@/hooks/useGitHubData";
+import { useProjects } from "@/hooks/useProjects";
+
+const MobileDashboardView = ({ currentUser }: { currentUser: any }) => {
+  const { data: stats } = useGitHubStats(!!currentUser);
+  const { data: projects = [] } = useProjects();
+  const currentYear = new Date().getFullYear();
+  const { data: contributions = [] } = useGitHubContributions(currentYear, !!currentUser);
+
+  const contributionMap = contributions.reduce((acc, c) => {
+    acc[c.date] = c.count;
+    return acc;
+  }, {} as Record<string, number>);
+
+  const maxCount = Math.max(...contributions.map((c) => c.count), 1);
+  const yearStart = new Date(currentYear, 0, 1);
+  const yearEnd = new Date(currentYear, 11, 31);
+  const days = eachDayOfInterval({ start: yearStart, end: yearEnd });
+  const graphData = days.map((date) => {
+    const dateStr = formatISO(date, { representation: "date" });
+    const count = contributionMap[dateStr] || 0;
+    const level = count === 0 ? 0 : Math.ceil((count / maxCount) * 4);
+    return { date: dateStr, count, level: Math.min(level, 4) };
+  });
+
+  const totalTasks = projects.reduce((sum, project: any) => {
+    const steps = project.steps || [];
+    return sum + steps.reduce((stepSum: number, step: any) => stepSum + (step.tasks?.length || 0), 0);
+  }, 0);
+
+  const completedTasks = projects.reduce((sum, project: any) => {
+    const steps = project.steps || [];
+    return (
+      sum +
+      steps.reduce(
+        (stepSum: number, step: any) =>
+          stepSum + (step.tasks?.filter((task: any) => task.status === "Completed" || task.status === "Done").length || 0),
+        0
+      )
+    );
+  }, 0);
+
+  return (
+    <div className="p-4 space-y-4 overflow-x-hidden">
+      <Card className="bg-card/70">
+        <CardContent className="pt-4">
+          <div className="flex items-center gap-3">
+            <Avatar className="h-14 w-14 border border-primary/30">
+              <AvatarImage src={stats?.avatar_url || currentUser?.photoURL || undefined} />
+              <AvatarFallback>
+                {(stats?.login || currentUser?.displayName || "U").slice(0, 2).toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
+            <div className="min-w-0 flex-1">
+              <p className="text-lg font-semibold truncate">{stats?.name || currentUser?.displayName || "Dashboard"}</p>
+              <p className="text-xs text-muted-foreground truncate">
+                {stats?.bio || currentUser?.email || "Welcome to your mobile dashboard"}
+              </p>
+              <div className="mt-2 flex items-center gap-3 text-[11px] text-muted-foreground">
+                <span className="flex items-center gap-1">
+                  <Users className="h-3 w-3" />
+                  {stats?.followers ?? 0}
+                </span>
+                <span className="flex items-center gap-1">
+                  <Users className="h-3 w-3" />
+                  {stats?.following ?? 0}
+                </span>
+                <span className="flex items-center gap-1">
+                  <GitFork className="h-3 w-3" />
+                  {stats?.public_repos ?? projects.length}
+                </span>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="bg-card/70 overflow-hidden">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <Github className="h-4 w-4 text-primary" />
+            Contributions
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0 overflow-x-auto">
+          <ContributionGraph data={graphData} blockSize={9} blockMargin={2} blockRadius={2} className="min-w-[300px]">
+            <ContributionGraphTotalCount className="text-sm font-semibold mb-2" />
+            <ContributionGraphCalendar>
+              {({ activity, dayIndex, weekIndex }) => (
+                <ContributionGraphBlock key={`${weekIndex}-${dayIndex}`} activity={activity} dayIndex={dayIndex} weekIndex={weekIndex} />
+              )}
+            </ContributionGraphCalendar>
+            <div className="mt-2 flex justify-end">
+              <ContributionGraphLegend />
+            </div>
+          </ContributionGraph>
+        </CardContent>
+      </Card>
+
+      <div className="grid grid-cols-3 gap-2">
+        <Card className="bg-card/70">
+          <CardContent className="pt-3 pb-3 text-center">
+            <p className="text-base font-semibold">{projects.length}</p>
+            <p className="text-[11px] text-muted-foreground">Projects</p>
+          </CardContent>
+        </Card>
+        <Card className="bg-card/70">
+          <CardContent className="pt-3 pb-3 text-center">
+            <p className="text-base font-semibold">{totalTasks}</p>
+            <p className="text-[11px] text-muted-foreground">Tasks</p>
+          </CardContent>
+        </Card>
+        <Card className="bg-card/70">
+          <CardContent className="pt-3 pb-3 text-center">
+            <p className="text-base font-semibold">{completedTasks}</p>
+            <p className="text-[11px] text-muted-foreground">Done</p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default MobileDashboardView;

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -34,10 +34,6 @@ if (typeof window !== "undefined" && isValidRecaptchaSiteKey(recaptchaSiteKey)) 
     provider: new ReCaptchaV3Provider(recaptchaSiteKey),
     isTokenAutoRefreshEnabled: true,
   });
-} else if (import.meta.env.DEV && typeof window !== "undefined") {
-  console.info(
-    "[Firebase] App Check skipped: set VITE_RECAPTCHA_SITE_KEY to your reCAPTCHA v3 site key to enable.",
-  );
 }
 
 export const auth = getAuth(app);

--- a/src/mobile/pages/DashboardMobile.tsx
+++ b/src/mobile/pages/DashboardMobile.tsx
@@ -1,0 +1,5 @@
+import Dashboard from "@/pages/Dashboard";
+
+const DashboardMobile = () => <Dashboard />;
+
+export default DashboardMobile;

--- a/src/mobile/pages/IndexMobile.tsx
+++ b/src/mobile/pages/IndexMobile.tsx
@@ -1,0 +1,86 @@
+import { Link } from "react-router-dom";
+import { ArrowRight, CheckSquare, MessageSquare, CalendarDays, FolderKanban } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const features = [
+  {
+    title: "Workspace",
+    description: "Track projects and architecture in one place.",
+    icon: FolderKanban,
+  },
+  {
+    title: "Tasks",
+    description: "Assign and monitor task progress quickly.",
+    icon: CheckSquare,
+  },
+  {
+    title: "Chat & Meet",
+    description: "Collaborate with your team in real time.",
+    icon: MessageSquare,
+  },
+  {
+    title: "Calendar",
+    description: "Stay aligned with deadlines and meetings.",
+    icon: CalendarDays,
+  },
+];
+
+const IndexMobile = () => {
+  return (
+    <div className="min-h-screen bg-transparent px-4 py-6">
+      <div className="mx-auto max-w-md space-y-6">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <img src="/zync-dark.webp" alt="Zync" className="h-9 w-9 rounded-lg object-contain" />
+            <span className="text-lg font-semibold text-foreground">Zync</span>
+          </div>
+          <Link to="/login" className="text-sm text-primary">
+            Login
+          </Link>
+        </div>
+
+        <section className="space-y-3">
+          <h1 className="text-3xl font-bold tracking-tight text-foreground">
+            Build Faster With Your Team
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Planning, tasks, chat, notes, and progress in one mobile-ready workspace.
+          </p>
+          <div className="grid grid-cols-1 gap-3 pt-1">
+            <Button asChild className="w-full">
+              <Link to="/signup">
+                Get Started
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+            <Button asChild variant="outline" className="w-full">
+              <Link to="/dashboard">Open Dashboard</Link>
+            </Button>
+          </div>
+        </section>
+
+        <section className="space-y-3 pb-4">
+          {features.map((feature) => {
+            const Icon = feature.icon;
+            return (
+              <Card key={feature.title} className="bg-card/70">
+                <CardHeader className="pb-2">
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    <Icon className="h-4 w-4 text-primary" />
+                    {feature.title}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="pt-0 text-sm text-muted-foreground">
+                  {feature.description}
+                </CardContent>
+              </Card>
+            );
+          })}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default IndexMobile;

--- a/src/mobile/pages/LoginMobile.tsx
+++ b/src/mobile/pages/LoginMobile.tsx
@@ -1,0 +1,5 @@
+import Login from "@/pages/Login";
+
+const LoginMobile = () => <Login />;
+
+export default LoginMobile;

--- a/src/mobile/pages/NewProjectMobile.tsx
+++ b/src/mobile/pages/NewProjectMobile.tsx
@@ -1,0 +1,5 @@
+import NewProject from "@/pages/NewProject";
+
+const NewProjectMobile = () => <NewProject />;
+
+export default NewProjectMobile;

--- a/src/mobile/pages/NotFoundMobile.tsx
+++ b/src/mobile/pages/NotFoundMobile.tsx
@@ -1,0 +1,5 @@
+import NotFound from "@/pages/NotFound";
+
+const NotFoundMobile = () => <NotFound />;
+
+export default NotFoundMobile;

--- a/src/mobile/pages/PrivacyMobile.tsx
+++ b/src/mobile/pages/PrivacyMobile.tsx
@@ -1,0 +1,5 @@
+import Privacy from "@/pages/Privacy";
+
+const PrivacyMobile = () => <Privacy />;
+
+export default PrivacyMobile;

--- a/src/mobile/pages/PrivacyPolicyMobile.tsx
+++ b/src/mobile/pages/PrivacyPolicyMobile.tsx
@@ -1,0 +1,5 @@
+import PrivacyPolicy from "@/pages/PrivacyPolicy";
+
+const PrivacyPolicyMobile = () => <PrivacyPolicy />;
+
+export default PrivacyPolicyMobile;

--- a/src/mobile/pages/ProjectDetailsMobile.tsx
+++ b/src/mobile/pages/ProjectDetailsMobile.tsx
@@ -1,0 +1,5 @@
+import ProjectDetails from "@/pages/ProjectDetails";
+
+const ProjectDetailsMobile = () => <ProjectDetails />;
+
+export default ProjectDetailsMobile;

--- a/src/mobile/pages/SignupMobile.tsx
+++ b/src/mobile/pages/SignupMobile.tsx
@@ -1,0 +1,5 @@
+import Signup from "@/pages/Signup";
+
+const SignupMobile = () => <Signup />;
+
+export default SignupMobile;

--- a/src/mobile/pages/TermsMobile.tsx
+++ b/src/mobile/pages/TermsMobile.tsx
@@ -1,0 +1,5 @@
+import Terms from "@/pages/Terms";
+
+const TermsMobile = () => <Terms />;
+
+export default TermsMobile;

--- a/src/mobile/pages/WelcomeToZyncMobile.tsx
+++ b/src/mobile/pages/WelcomeToZyncMobile.tsx
@@ -1,0 +1,5 @@
+import WelcomeToZync from "@/pages/WelcomeToZync";
+
+const WelcomeToZyncMobile = () => <WelcomeToZync />;
+
+export default WelcomeToZyncMobile;


### PR DESCRIPTION
## Summary
- add a dedicated mobile dashboard view and route Home tab to the mobile-safe layout to prevent horizontal overflow
- improve mobile activity UX with user profile summary, team member drill-down stats, and cleaner time formatting (hide 0h)
- fix mobile navigation and accessibility by auto-closing the drawer on page selection and adding missing dialog/sheet title+description metadata

## Test plan
- [ ] Open app in mobile viewport and verify Home no longer slides horizontally
- [ ] Open side drawer, tap any menu item, and confirm drawer closes after navigation
- [ ] Open Activity tab and verify profile summary + member expand/collapse stats render correctly
- [ ] Confirm settings top tabs can be swiped horizontally on mobile
- [ ] Verify console no longer shows DialogContent/SheetContent accessibility warnings