### PR TITLE
feat: mobile navigation updates, blunt dashboard corners, and authentication redirects

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["dist", "dist-electron", "node_modules", "coverage", "public", "backend/"] },
+  { ignores: ["dist", "dist-electron", "node_modules", "coverage", "public", "backend/", "dev-dist"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],

--- a/src/components/layout/MobileLayout.tsx
+++ b/src/components/layout/MobileLayout.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Menu, Search, Plus, Home, Video, CheckSquare, Bell, Settings } from 'lucide-react';
+import { Menu, Search, Plus, Home, Users, Calendar, FileText, CheckSquare, Video } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { useNavigate } from 'react-router-dom';
 
 interface MobileLayoutProps {
     children: React.ReactNode;
@@ -31,17 +32,27 @@ export const MobileLayout = ({
     rightHeaderAction
 }: MobileLayoutProps) => {
     const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
+    const navigate = useNavigate();
 
-    const navItems = [
+    const leftItems = [
         { id: 'Home', icon: Home, label: 'Home' },
-        { id: 'Meet', icon: Video, label: 'Meet' },
-        { id: 'Tasks', icon: CheckSquare, label: 'Tasks' },
-        { id: 'Activity', icon: Bell, label: 'Activity' },
-        { id: 'Settings', icon: Settings, label: 'Settings' },
+        { id: 'People', icon: Users, label: 'People' },
+        { id: 'Calendar', icon: Calendar, label: 'Cal' },
     ];
 
+    const rightItems = [
+        { id: 'Notes', icon: FileText, label: 'Notes' },
+        { id: 'Tasks', icon: CheckSquare, label: 'Tasks' },
+        { id: 'Meet', icon: Video, label: 'Meet' },
+    ];
 
-    const isMainTab = navItems.some(item => item.id === activeTab);
+    const handleFabClick = () => {
+        if (onFabClick) {
+            onFabClick();
+        } else {
+            navigate('/new-project');
+        }
+    };
 
     return (
         <div className="flex flex-col h-screen w-full bg-background text-foreground overflow-hidden">
@@ -111,22 +122,9 @@ export const MobileLayout = ({
 
             {}
             {}
-            {onFabClick && (
-                <div className="absolute bottom-20 right-4 z-50">
-                    <Button
-                        onClick={onFabClick}
-                        size="icon"
-                        className="h-14 w-14 rounded-full shadow-xl bg-primary text-primary-foreground hover:bg-primary/90 transition-transform active:scale-95"
-                    >
-                        <Plus className="h-6 w-6" />
-                    </Button>
-                </div>
-            )}
-
-            {}
-            <nav className="h-16 border-t border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 shrink-0 z-40 pb-safe">
-                <div className="grid grid-cols-5 h-full">
-                    {navItems.map((item) => {
+            <nav className="h-16 border-t border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 shrink-0 z-40 pb-safe px-3">
+                <div className="flex items-center justify-between h-full max-w-lg mx-auto relative">
+                    {leftItems.map((item) => {
                         const isActive = activeTab === item.id;
                         const Icon = item.icon;
 
@@ -135,7 +133,7 @@ export const MobileLayout = ({
                                 key={item.id}
                                 onClick={() => onTabChange(item.id)}
                                 className={cn(
-                                    "flex flex-col items-center justify-center gap-1 transition-colors relative group",
+                                    "flex flex-col items-center justify-center flex-1 py-1 transition-colors relative group",
                                     isActive ? "text-primary" : "text-muted-foreground hover:text-foreground"
                                 )}
                             >
@@ -145,9 +143,43 @@ export const MobileLayout = ({
                                 )}>
                                     <Icon className={cn("h-5 w-5", isActive && "fill-current")} />
                                 </div>
-                                <span className="text-[10px] font-medium">{item.label}</span>
+                                <span className="text-[9px] font-medium mt-0.5">{item.label}</span>
                             </button>
-                        )
+                        );
+                    })}
+
+                    {/* Middle FAB */}
+                    <div className="relative -top-4 px-2 shrink-0 z-50">
+                        <button
+                            onClick={handleFabClick}
+                            className="w-12 h-12 rounded-full bg-primary text-primary-foreground shadow-lg shadow-primary/20 flex items-center justify-center ring-4 ring-background hover:bg-primary/95 transition-transform active:scale-95"
+                        >
+                            <Plus className="w-6 h-6" />
+                        </button>
+                    </div>
+
+                    {rightItems.map((item) => {
+                        const isActive = activeTab === item.id;
+                        const Icon = item.icon;
+
+                        return (
+                            <button
+                                key={item.id}
+                                onClick={() => onTabChange(item.id)}
+                                className={cn(
+                                    "flex flex-col items-center justify-center flex-1 py-1 transition-colors relative group",
+                                    isActive ? "text-primary" : "text-muted-foreground hover:text-foreground"
+                                )}
+                            >
+                                <div className={cn(
+                                    "p-1.5 rounded-xl transition-all duration-200",
+                                    isActive ? "bg-primary/10" : "group-hover:bg-muted"
+                                )}>
+                                    <Icon className={cn("h-5 w-5", isActive && "fill-current")} />
+                                </div>
+                                <span className="text-[9px] font-medium mt-0.5">{item.label}</span>
+                            </button>
+                        );
                     })}
                 </div>
             </nav>

--- a/src/components/views/DesktopView.tsx
+++ b/src/components/views/DesktopView.tsx
@@ -949,7 +949,7 @@ const DesktopView = ({ isPreview = false }: { isPreview?: boolean }) => {
                     localStorage.removeItem("ZYNC-active-section");
                     localStorage.removeItem("ZYNC_HAS_SEEN_LANDING"); // Reset landing page state
                     await signOutAndClearState(auth);
-                    navigate("/login");
+                    navigate("/");
                   }} className="text-rose-500 focus:text-rose-400 focus:bg-rose-500/10 cursor-pointer py-2">
                     <LogOut className="mr-2 h-4 w-4" />
                     <span>Sign out</span>

--- a/src/components/views/DesktopView.tsx
+++ b/src/components/views/DesktopView.tsx
@@ -967,7 +967,7 @@ const DesktopView = ({ isPreview = false }: { isPreview?: boolean }) => {
         {/* Main Content Panel - The "Card" Look */}
         <Panel defaultSize={84} className="min-h-0 bg-transparent">
           <div className="h-full w-full p-0 bg-transparent -ml-2">
-            <div className="h-full w-full bg-transparent rounded-r-[32px] rounded-l-none overflow-hidden relative border-none shadow-none flex flex-col">
+            <div className="h-full w-full bg-transparent rounded-[32px] overflow-hidden relative border-none shadow-none flex flex-col">
               {/* Header - Always show for main app content */}
               <div className="flex items-center justify-between px-8 py-5 bg-transparent backdrop-blur-none sticky top-0 z-20">
                 <div className="flex items-center gap-4">

--- a/src/components/views/DesktopView.tsx
+++ b/src/components/views/DesktopView.tsx
@@ -837,7 +837,7 @@ const DesktopView = ({ isPreview = false }: { isPreview?: boolean }) => {
 
     <div className="h-screen w-full relative text-foreground overflow-hidden font-sans">
       {/* Full-viewport canvas — main column is transparent so this is visible (not body bg-black). */}
-      <div className="pointer-events-none fixed inset-0 z-0 dashboard-backdrop" aria-hidden />
+      <div className="pointer-events-none fixed inset-0 z-0 bg-background" aria-hidden />
 
       {/* Full Screen Landing Page Overlay */}
       {isLanding && (
@@ -966,8 +966,8 @@ const DesktopView = ({ isPreview = false }: { isPreview?: boolean }) => {
 
         {/* Main Content Panel - The "Card" Look */}
         <Panel defaultSize={84} className="min-h-0 bg-transparent">
-          <div className="h-full w-full p-3 pl-1 bg-transparent">
-            <div className="h-full w-full bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-900/80 rounded-[24px] overflow-hidden relative shadow-2xl flex flex-col">
+          <div className="h-full w-full p-0 bg-transparent -ml-2">
+            <div className="h-full w-full dashboard-backdrop rounded-[32px] overflow-hidden relative border-none shadow-none flex flex-col">
               {/* Header - Always show for main app content */}
               <div className="flex items-center justify-between px-8 py-5 bg-transparent backdrop-blur-none sticky top-0 z-20">
                 <div className="flex items-center gap-4">

--- a/src/components/views/DesktopView.tsx
+++ b/src/components/views/DesktopView.tsx
@@ -966,8 +966,8 @@ const DesktopView = ({ isPreview = false }: { isPreview?: boolean }) => {
 
         {/* Main Content Panel - The "Card" Look */}
         <Panel defaultSize={84} className="min-h-0 bg-transparent">
-          <div className="h-full w-full p-0 bg-transparent -ml-2">
-            <div className="h-full w-full bg-transparent rounded-[32px] overflow-hidden relative border-none shadow-none flex flex-col">
+          <div className="h-full w-full p-3 pl-1 bg-transparent">
+            <div className="h-full w-full bg-zinc-900/10 dark:bg-zinc-950/40 border border-black/10 dark:border-white/5 rounded-[24px] overflow-hidden relative shadow-2xl flex flex-col">
               {/* Header - Always show for main app content */}
               <div className="flex items-center justify-between px-8 py-5 bg-transparent backdrop-blur-none sticky top-0 z-20">
                 <div className="flex items-center gap-4">

--- a/src/components/views/DesktopView.tsx
+++ b/src/components/views/DesktopView.tsx
@@ -967,7 +967,7 @@ const DesktopView = ({ isPreview = false }: { isPreview?: boolean }) => {
         {/* Main Content Panel - The "Card" Look */}
         <Panel defaultSize={84} className="min-h-0 bg-transparent">
           <div className="h-full w-full p-3 pl-1 bg-transparent">
-            <div className="h-full w-full bg-zinc-900/10 dark:bg-zinc-950/40 border border-black/10 dark:border-white/5 rounded-[24px] overflow-hidden relative shadow-2xl flex flex-col">
+            <div className="h-full w-full bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-900/80 rounded-[24px] overflow-hidden relative shadow-2xl flex flex-col">
               {/* Header - Always show for main app content */}
               <div className="flex items-center justify-between px-8 py-5 bg-transparent backdrop-blur-none sticky top-0 z-20">
                 <div className="flex items-center gap-4">

--- a/src/components/views/DesktopView.tsx
+++ b/src/components/views/DesktopView.tsx
@@ -869,7 +869,7 @@ const DesktopView = ({ isPreview = false }: { isPreview?: boolean }) => {
           onCollapse={() => setIsCollapsed(true)}
           onExpand={() => setIsCollapsed(false)}
           className={cn(
-            "relative bg-black flex flex-col transition-all duration-300 ease-in-out h-full border-none after:content-[''] after:absolute after:top-0 after:-right-1 after:h-full after:w-2 after:bg-black after:pointer-events-none after:z-[90]",
+            "relative bg-black flex flex-col transition-all duration-300 ease-in-out h-full border-none",
             isCollapsed && "min-w-[70px]",
             // Animation logic: Hidden during landing, slides in when landing finishes
             isLanding ? "opacity-0 invisible" : ""
@@ -958,15 +958,13 @@ const DesktopView = ({ isPreview = false }: { isPreview?: boolean }) => {
               </DropdownMenu>
             </div>
           </div>
-          {/* Hard mask to remove sidebar/content seam */}
-          <div className="absolute top-0 right-0 h-full w-[2px] bg-black pointer-events-none z-[80]" />
         </Panel>
 
       <PanelResizeHandle className="w-px bg-transparent opacity-0" />
 
         {/* Main Content Panel - The "Card" Look */}
         <Panel defaultSize={84} className="min-h-0 bg-transparent">
-          <div className="h-full w-full p-0 bg-transparent -ml-2">
+          <div className="h-full w-full p-0 bg-transparent">
             <div className="h-full w-full dashboard-backdrop rounded-[32px] overflow-hidden relative border-none shadow-none flex flex-col">
               {/* Header - Always show for main app content */}
               <div className="flex items-center justify-between px-8 py-5 bg-transparent backdrop-blur-none sticky top-0 z-20">

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -558,10 +558,10 @@ export default function SettingsView() {
   };
 
   return (
-    <div className="flex-1 h-full overflow-y-auto bg-transparent p-3 sm:p-6">
-      <div className="max-w-4xl mx-auto space-y-8">
-        <Tabs defaultValue="profile" className="space-y-6">
-          <div className="w-full overflow-x-auto pb-1 scrollbar-thin">
+    <div className="flex-1 h-full overflow-hidden bg-transparent">
+      <div className="max-w-4xl mx-auto h-full flex flex-col px-3 sm:px-6">
+        <Tabs defaultValue="profile" className="flex flex-col h-full space-y-6">
+          <div className="w-full overflow-x-auto pt-3 sm:pt-6 pb-1 scrollbar-thin shrink-0">
             <TabsList className="bg-black border border-white/10 inline-flex w-max min-w-full sm:min-w-0 whitespace-nowrap">
               <TabsTrigger value="profile" className="shrink-0">My Profile</TabsTrigger>
               <TabsTrigger value="team" className="shrink-0">Team</TabsTrigger>
@@ -571,6 +571,8 @@ export default function SettingsView() {
               <TabsTrigger value="security" className="shrink-0">Security</TabsTrigger>
             </TabsList>
           </div>
+
+          <div className="flex-1 overflow-y-auto pb-6 scrollbar-thin focus-visible:outline-none">
 
           {}
           <TabsContent value="profile">
@@ -927,6 +929,7 @@ export default function SettingsView() {
               </CardContent>
             </Card>
           </TabsContent>
+          </div>
         </Tabs>
       </div>
     </div>

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -95,6 +95,11 @@ export default function SettingsView() {
 
 
   const queryClient = useQueryClient();
+  const isGitHubLinked = !!userData?.githubIntegration?.connected;
+
+  const setUserData = useCallback((updater: any) => {
+    queryClient.setQueryData(['me', currentUser?.uid], updater);
+  }, [queryClient, currentUser?.uid]);
 
 
   const [profileForm, setProfileForm] = useState({
@@ -406,17 +411,29 @@ export default function SettingsView() {
         <DelayedLoaderGate active={true}>
           <div className="max-w-4xl mx-auto space-y-6">
             <div className="flex items-center gap-4 mb-8">
-              <Skeleton name="settings-header-title" className="h-10 w-48 rounded-md" />
+              <Skeleton name="settings-header-title" loading={true}>
+                <div className="h-10 w-48 rounded-md bg-zinc-800/80" />
+              </Skeleton>
             </div>
-            <Skeleton name="settings-tabs" className="h-10 w-full rounded-md" />
+            <Skeleton name="settings-tabs" loading={true}>
+              <div className="h-10 w-full rounded-md bg-zinc-800/80" />
+            </Skeleton>
             <Card>
               <CardHeader>
-                <Skeleton name="settings-card-header" className="h-8 w-32 rounded-md" />
+                <Skeleton name="settings-card-header" loading={true}>
+                  <div className="h-8 w-32 rounded-md bg-zinc-800/80" />
+                </Skeleton>
               </CardHeader>
               <CardContent className="space-y-4">
-                <Skeleton name="settings-input-1" className="h-10 w-full rounded-md" />
-                <Skeleton name="settings-input-2" className="h-10 w-full rounded-md" />
-                <Skeleton name="settings-input-3" className="h-10 w-full rounded-md" />
+                <Skeleton name="settings-input-1" loading={true}>
+                  <div className="h-10 w-full rounded-md bg-zinc-800/80" />
+                </Skeleton>
+                <Skeleton name="settings-input-2" loading={true}>
+                  <div className="h-10 w-full rounded-md bg-zinc-800/80" />
+                </Skeleton>
+                <Skeleton name="settings-input-3" loading={true}>
+                  <div className="h-10 w-full rounded-md bg-zinc-800/80" />
+                </Skeleton>
               </CardContent>
             </Card>
           </div>
@@ -742,7 +759,7 @@ export default function SettingsView() {
                   <Button
                     variant={isCalendarSynced ? "destructive" : "secondary"}
                     onClick={isCalendarSynced ? handleGoogleDisconnect : handleGoogleConnect}
-                    disabled={loading}
+                    disabled={isConnectingGoogle}
                   >
                     {isCalendarSynced ? "Disconnect" : (isGoogleLinked ? "Enable Sync" : "Connect")}
                   </Button>

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -40,7 +40,6 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { useTheme } from "next-themes";
-import { useQueryClient } from "@tanstack/react-query";
 
 
 const countries = [

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -409,7 +409,7 @@ export default function SettingsView() {
     return (
       <div className="min-h-screen bg-background p-6">
         <DelayedLoaderGate active={true}>
-          <div className="max-w-4xl mx-auto space-y-6">
+          <div className="w-full space-y-6">
             <div className="flex items-center gap-4 mb-8">
               <Skeleton name="settings-header-title" loading={true}>
                 <div className="h-10 w-48 rounded-md bg-zinc-800/80" />
@@ -559,7 +559,7 @@ export default function SettingsView() {
 
   return (
     <div className="flex-1 h-full overflow-hidden bg-transparent">
-      <div className="max-w-4xl mx-auto h-full flex flex-col px-3 sm:px-6">
+      <div className="w-full h-full flex flex-col px-3 sm:px-6">
         <Tabs defaultValue="profile" className="flex flex-col h-full space-y-6">
           <div className="w-full overflow-x-auto pt-3 sm:pt-6 pb-1 scrollbar-thin shrink-0">
             <TabsList className="bg-black border border-white/10 inline-flex w-max min-w-full sm:min-w-0 whitespace-nowrap">

--- a/src/pages/ProjectDetails.tsx
+++ b/src/pages/ProjectDetails.tsx
@@ -15,7 +15,7 @@ import { auth } from "@/lib/firebase";
 import { sendMessage as socketSendMessage } from "@/services/chatSocketService";
 import { useTaskUpdates } from "@/hooks/use-task-updates";
 import KanbanBoard from "@/components/workspace/KanbanBoard";
-import { ActivityGraph } from "@/components/views/activity/ActivityGraph";
+import { ActivityGraph } from "@/components/views/ActivityGraph";
 import { io } from "socket.io-client";
 import { toast } from "sonner";
 import ReactMarkdown from 'react-markdown';


### PR DESCRIPTION
This Pull Request introduces major layout improvements, mobile navigation redesigns, and key authentication routing fixes across the Zync platform.

### Key Features & Changes

#### 1. Redesigned Mobile Bottom Navigation Bar (`MobileLayout.tsx`)
- **Landing Page Mockup Alignment**: Updated the mobile bottom navigation bar to match the exact design and items shown in the landing page mobile preview (`MobilePreview.tsx`).
- **7-Column Layout**: Integrated a clean flex-row layout featuring:
  - **Left Group**: Home (Dashboard), People (Team), and Cal (Calendar).
  - **Center Elevated FAB**: A prominent elevated Plus FAB button that triggers a project creation flow or navigates directly to `/new-project`.
  - **Right Group**: Notes, Tasks, and Meet.
- **Unified Interface**: Cleaned up the layout by removing the duplicate bottom-right floating FAB.

#### 2. Blunt Rounded Corners on Dashboard (`DesktopView.tsx`)
- **Blunt Edge Aesthetics**: Added `rounded-[32px]` corners to the main dashboard container area to give it a modern card-like feel.
- **Removed Sidebar Overlaps**: Removed the sidebar's absolute pseudo-element and `bg-black` hard mask dividers, and removed the `-ml-2` negative offset from the dashboard panel. This allows the left rounded corners to render perfectly next to the sidebar without being cut off.
- **Theme Gradient Wallpaper**: Containerized the `dashboard-backdrop` color theme linear/radial gradient directly inside the rounded dashboard panel rather than stretching it across the full viewport, creating a distinct visual boundary.

#### 3. Settings Page Scrolling & Width Layout (`SettingsView.tsx`)
- **Fixed Navbar / Scrollable Content**: Restructured the Settings layout to use a flex column layout where the tab navigation bar (`TabsList` containing My Profile, Team, Preferences, Integrations, Support, Security) stays fixed at the top, and only the active tab content area (`TabsContent`) is scrollable. This prevents the navigation bar from scrolling out of view when adjusting account preferences.
- **Full-Width Desktop Design**: Removed `max-w-4xl mx-auto` restrictions from both the skeleton loading screen and the main Settings view wrapper. Settings now uses the full viewport width on laptop/desktop layouts, perfectly matching the design of other dashboard pages.

#### 4. Authentication Routing & Redirects (`DesktopView.tsx`)
- **Sign-Out Flow**: Updated the profile dropdown's sign-out callback to redirect users directly back to the landing page (`/`) instead of the login page (`/login`).

#### 5. TypeScript & Import Fixes (`SettingsView.tsx`, `ProjectDetails.tsx`)
- **Skeleton Types**: Wrapped placeholder elements in the `Skeleton` wrapper in `SettingsView.tsx` and supplied the required `loading` prop to satisfy TypeScript compiler rules.
- **Import Paths**: Fixed the named import path for the `ActivityGraph` component in `ProjectDetails.tsx` to reference the correct component file directory.
- **State Helpers**: Added `isGitHubLinked` and a React Query query-cache wrapper for `setUserData` inside `SettingsView.tsx`.
