### PR TITLE
feat: Local-First Yjs Multiplayer Editor

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-5a5d9309'], (function (workbox) { 'use strict';
     "revision": "d41d8cd98f00b204e9800998ecf8427e"
   }, {
     "url": "/index.html",
-    "revision": "0.hiikievei0k"
+    "revision": "0.2ag99n2nhn8"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("/index.html"), {

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,8 +102,10 @@
         "uuid": "^11.0.3",
         "vaul": "^1.1.2",
         "winston": "^3.17.0",
+        "y-indexeddb": "^9.0.12",
         "y-protocols": "^1.0.7",
-        "yjs": "^13.6.29",
+        "y-websocket": "^3.0.0",
+        "yjs": "^13.6.31",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -31700,6 +31702,26 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/y-indexeddb": {
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/y-indexeddb/-/y-indexeddb-9.0.12.tgz",
+      "integrity": "sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.74"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
     "node_modules/y-prosemirror": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.3.7.tgz",
@@ -31743,6 +31765,27 @@
       },
       "peerDependencies": {
         "yjs": "^13.0.0"
+      }
+    },
+    "node_modules/y-websocket": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/y-websocket/-/y-websocket-3.0.0.tgz",
+      "integrity": "sha512-mUHy7AzkOZ834T/7piqtlA8Yk6AchqKqcrCXjKW8J1w2lPtRDjz8W5/CvXz9higKAHgKRKqpI3T33YkRFLkPtg==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.102",
+        "y-protocols": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.5.6"
       }
     },
     "node_modules/y18n": {
@@ -31805,9 +31848,9 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.6.30",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.30.tgz",
-      "integrity": "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==",
+      "version": "13.6.31",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.31.tgz",
+      "integrity": "sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,8 +123,10 @@
     "uuid": "^11.0.3",
     "vaul": "^1.1.2",
     "winston": "^3.17.0",
+    "y-indexeddb": "^9.0.12",
     "y-protocols": "^1.0.7",
-    "yjs": "^13.6.29",
+    "y-websocket": "^3.0.0",
+    "yjs": "^13.6.31",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 
 import { useCreateBlockNote } from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/mantine";
@@ -14,53 +14,46 @@ import { EditorHeader } from './editor/EditorHeader';
 import { TaskDialogs } from './editor/TaskDialogs';
 import { ShareDialog } from './editor/ShareDialog';
 
+import * as Y from "yjs";
+import { IndexeddbPersistence } from "y-indexeddb";
+import { SocketIOProvider } from '../../lib/SocketIOProvider';
+
 interface NoteEditorProps {
   note: Note;
   user: { uid: string; displayName?: string; email?: string; photoURL?: string };
+  isShared?: boolean;
   onUpdate: (note: Note) => void;
   className?: string;
 }
 
-const NoteEditor: React.FC<NoteEditorProps> = ({ note, user, onUpdate, className }) => {
+const COLLABORATOR_COLORS = [
+  '#ef4444', '#f97316', '#eab308', '#22c55e', '#14b8a6', '#3b82f6', '#8b5cf6', '#ec4899', '#06b6d4', '#a855f7'
+];
+
+export const getColorForUser = (userId: string): string => {
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = userId.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return COLLABORATOR_COLORS[Math.abs(hash) % COLLABORATOR_COLORS.length];
+};
+
+// ---------------------------------------------------------------------------
+// INNER EDITOR COMPONENT (Only renders when Y.Doc is fully ready)
+// ---------------------------------------------------------------------------
+const NoteEditorInner: React.FC<NoteEditorProps & { doc: Y.Doc, provider: any, isEditable: boolean }> = ({ 
+  note, user, onUpdate, className, doc, provider, isEditable 
+}) => {
   const [title, setTitle] = useState(note.title || '');
   const [status, setStatus] = useState<'Saved' | 'Saving...'>('Saved');
-  const [isEditable, setIsEditable] = useState(true);
-
-  useEffect(() => {
-    if (user.uid === note.ownerId) {
-      setIsEditable(true);
-      return;
-    }
-
-    const noteAny = note as any;
-    const userRole = noteAny.permissions?.[user.uid] || noteAny.role;
-
-    if (userRole === 'viewer') {
-      setIsEditable(false);
-    } else {
-      setIsEditable(true);
-    }
-  }, [note, user.uid]);
-
-  const {
-    activeUsers,
-    remoteCursors,
-    updateCursorPosition,
-  } = useNotePresence(note.id, user);
-
+  
   const [projects, setProjects] = useState<Project[]>([]);
   const [taskDialogOpen, setTaskDialogOpen] = useState(false);
   const [taskLinkDialogOpen, setTaskLinkDialogOpen] = useState(false);
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
   const [selectedTaskText, setSelectedTaskText] = useState("");
 
-  const editorOptions = useMemo(() => ({
-    initialContent: note.content && Array.isArray(note.content) && note.content.length > 0
-      ? note.content
-      : undefined,
-  }), [note.id]); // Re-init on note change
-
-  const editor = useCreateBlockNote(editorOptions);
+  const { activeUsers } = useNotePresence(note.id, user);
 
   useEffect(() => {
     setTitle(note.title || '');
@@ -86,25 +79,39 @@ const NoteEditor: React.FC<NoteEditorProps> = ({ note, user, onUpdate, className
     }
   };
 
-  const saveTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
+  const editorOptions = useMemo(() => ({
+    collaboration: {
+      provider,
+      fragment: doc.getXmlFragment("document"),
+      user: {
+        name: user.displayName || 'Anonymous',
+        color: getColorForUser(user.uid)
+      }
+    }
+  }), [provider, doc, user]);
+
+  const editor = useCreateBlockNote(editorOptions);
+
+  // 1-TIME HYDRATION: If Y.Doc is completely empty (new local instance) but we have server content
+  const [hasHydrated, setHasHydrated] = useState(false);
+  useEffect(() => {
+    if (editor && note.content && !hasHydrated) {
+      if (editor.document.length === 1 && !editor.document[0].content) {
+        if (Array.isArray(note.content) && note.content.length > 0) {
+          editor.replaceBlocks(editor.document, note.content);
+        }
+      }
+      setHasHydrated(true);
+    }
+  }, [editor, note.content, hasHydrated]);
+
+  const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const handleContentChange = useCallback(() => {
-    if (!isEditable) {return;}
-
+    if (!isEditable) return;
     setStatus('Saving...');
 
-    try {
-      const cursorPos = editor.getTextCursorPosition();
-      if (cursorPos?.block?.id) {
-        updateCursorPosition(cursorPos.block.id);
-      }
-    } catch (e) {
-      // Ignore errors when failing to get cursor position
-    }
-
-    if (saveTimeoutRef.current) {
-      clearTimeout(saveTimeoutRef.current);
-    }
+    if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
 
     saveTimeoutRef.current = setTimeout(async () => {
       try {
@@ -112,73 +119,19 @@ const NoteEditor: React.FC<NoteEditorProps> = ({ note, user, onUpdate, className
         await updateNote(note.id, { content: blocks });
         setStatus('Saved');
       } catch (error) {
-        console.error("Failed to save content", error);
         toast.error("Failed to save changes");
       }
     }, 2000);
-  }, [editor, note.id, updateCursorPosition, isEditable]);
-
-  const handleBlockFocus = useCallback(() => {
-    try {
-      const cursorPos = editor?.getTextCursorPosition();
-      if (cursorPos?.block?.id) {
-        updateCursorPosition(cursorPos.block.id);
-      }
-    } catch (e) {
-      // Ignore errors when failing to get cursor position on focus
-    }
-  }, [editor, updateCursorPosition]);
+  }, [editor, note.id, isEditable]);
 
   useEffect(() => {
     return () => {
-      if (saveTimeoutRef.current) {
-        clearTimeout(saveTimeoutRef.current);
-      }
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
     };
   }, []);
 
-  useEffect(() => {
-    if (!editor) {return;}
-
-    // Clear previous highlights
-    const previousHighlights = document.querySelectorAll('[data-collab-user]');
-    previousHighlights.forEach(el => {
-      el.removeAttribute('data-collab-user');
-      el.removeAttribute('data-collab-color');
-      el.removeAttribute('data-collab-name');
-      (el as HTMLElement).style.removeProperty('--collab-color');
-      (el as HTMLElement).style.removeProperty('border-left');
-    });
-
-    if (activeUsers.length === 0) {
-      return;
-    }
-
-    const blocks = editor.document;
-    blocks.forEach(block => {
-      const activeCollaborator = remoteCursors[block.id] || null;
-
-      if (activeCollaborator) {
-        let blockEl = document.querySelector(`.bn-block-outer[data-id="${block.id}"]`);
-        if (!blockEl) { blockEl = document.querySelector(`[data-id="${block.id}"]`); }
-        if (!blockEl) { blockEl = document.querySelector(`[data-node-id="${block.id}"]`); }
-        if (!blockEl) { blockEl = document.querySelector(`[data-block-id="${block.id}"]`); }
-
-        if (blockEl) {
-          blockEl.setAttribute('data-collab-user', activeCollaborator.id);
-          blockEl.setAttribute('data-collab-color', activeCollaborator.color);
-          blockEl.setAttribute('data-collab-name', activeCollaborator.name || 'Someone');
-          (blockEl as HTMLElement).style.setProperty('--collab-color', activeCollaborator.color);
-          (blockEl as HTMLElement).style.borderLeft = `3px solid ${activeCollaborator.color}`;
-          (blockEl as HTMLElement).style.position = 'relative';
-        }
-      }
-    });
-  }, [editor, activeUsers, remoteCursors]);
-
   const openTaskCreation = () => {
-    if (!editor) {return;}
-
+    if (!editor) return;
     const selection = editor.getTextCursorPosition();
     const block = selection.block;
     let text = "";
@@ -207,48 +160,19 @@ const NoteEditor: React.FC<NoteEditorProps> = ({ note, user, onUpdate, className
   };
 
   const handleInsertTaskLink = async (task: TaskSearchResult) => {
-    if (!editor) {return;}
-
+    if (!editor) return;
     editor.insertBlocks([
       {
         content: [
-          {
-            type: "text",
-            text: task.title + " ",
-            styles: { bold: true }
-          },
-          {
-            type: "link",
-            href: `/projects/${task.projectId}?task=${task.id}`,
-            content: [{ type: "text", text: "🔗", styles: {} }]
-          }
+          { type: "text", text: task.title + " ", styles: { bold: true } },
+          { type: "link", href: `/projects/${task.projectId}?task=${task.id}`, content: [{ type: "text", text: "🔗", styles: {} }] }
         ]
       }
     ], editor.getTextCursorPosition().block, "after");
-
     setTaskLinkDialogOpen(false);
   };
 
-  useEffect(() => {
-    if (!editor || !note.content) {return;}
-
-    try {
-      const currentContent = JSON.stringify(editor.document);
-      const newContent = JSON.stringify(note.content);
-
-      if (currentContent !== newContent) {
-        if (Array.isArray(note.content)) {
-          editor.replaceBlocks(editor.document, note.content);
-        }
-      }
-    } catch (e) {
-      console.error("Failed to sync content", e);
-    }
-  }, [note.content, editor]);
-
-  if (!editor) {
-    return <div className="h-full w-full flex items-center justify-center text-sm text-muted-foreground">Loading editor…</div>;
-  }
+  if (!editor) return <div className="h-full w-full flex items-center justify-center text-sm text-muted-foreground">Loading editor…</div>;
 
   return (
     <div className={cn("flex flex-col h-full", className)}>
@@ -273,11 +197,7 @@ const NoteEditor: React.FC<NoteEditorProps> = ({ note, user, onUpdate, className
               onTitleChange={handleTitleChange}
             />
 
-            <div
-              className="prose dark:prose-invert prose-neutral max-w-none prose-headings:text-foreground prose-p:text-muted-foreground prose-a:text-foreground prose-lg"
-              onClick={handleBlockFocus}
-              onKeyUp={handleBlockFocus}
-            >
+            <div className="prose dark:prose-invert prose-neutral max-w-none prose-headings:text-foreground prose-p:text-muted-foreground prose-a:text-foreground prose-lg">
               <BlockNoteView
                 editor={editor}
                 editable={isEditable}
@@ -313,11 +233,72 @@ const NoteEditor: React.FC<NoteEditorProps> = ({ note, user, onUpdate, className
   );
 };
 
+// ---------------------------------------------------------------------------
+// OUTER WRAPPER (Manages Yjs + IndexedDB Setup + WebSocket)
+// ---------------------------------------------------------------------------
+const NoteEditor: React.FC<NoteEditorProps> = (props) => {
+  const { note, user, isShared } = props;
+  const [doc, setDoc] = useState<Y.Doc>();
+  const [provider, setProvider] = useState<any>();
+  const [isEditable, setIsEditable] = useState(true);
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    if (user.uid === note.ownerId) {
+      setIsEditable(true);
+    } else {
+      const noteAny = note as any;
+      const userRole = noteAny.permissions?.[user.uid] || noteAny.role;
+      setIsEditable(userRole !== 'viewer');
+    }
+  }, [note, user.uid]);
+
+  useEffect(() => {
+    const ydoc = new Y.Doc();
+    const idbProvider = new IndexeddbPersistence(`zync-note-${note.id}`, ydoc);
+    let wsProvider: SocketIOProvider | null = null;
+
+    idbProvider.on('synced', () => {
+      if (isShared) {
+        wsProvider = new SocketIOProvider(note.id, ydoc, {
+          name: user.displayName || 'Anonymous',
+          color: getColorForUser(user.uid)
+        });
+        setProvider(wsProvider);
+      } else {
+        setProvider(idbProvider);
+      }
+      setDoc(ydoc);
+      setIsReady(true);
+    });
+
+    return () => {
+      idbProvider.destroy();
+      if (wsProvider) {
+        wsProvider.destroy();
+      }
+      ydoc.destroy();
+      setIsReady(false);
+    };
+  }, [note.id, isShared, user]);
+
+  if (!isReady || !doc || !provider) {
+    return <div className="h-full w-full flex items-center justify-center text-sm text-muted-foreground">Initializing offline storage…</div>;
+  }
+
+  return (
+    <NoteEditorInner 
+      {...props} 
+      doc={doc} 
+      provider={provider} 
+      isEditable={isEditable} 
+    />
+  );
+};
+
 export default React.memo(NoteEditor, (prev, next) => {
   const isSameNote = prev.note.id === next.note.id;
-  const isSameTitle = prev.note.title === next.note.title;
   const isSameUser = prev.user.uid === next.user.uid;
-  const isSameContent = prev.note.content === next.note.content;
-
-  return isSameNote && isSameTitle && isSameUser && isSameContent;
+  const isSameShared = prev.isShared === next.isShared;
+  return isSameNote && isSameUser && isSameShared;
 });

--- a/src/components/notes/NotesLayout.tsx
+++ b/src/components/notes/NotesLayout.tsx
@@ -799,6 +799,7 @@ export const NotesLayout: React.FC<NotesLayoutProps> = ({ user, users = [], init
                 key={selectedNote.id}
                 note={selectedNote}
                 user={{ uid: user.uid, displayName: user.displayName, email: user.email, photoURL: user.photoURL }}
+                isShared={selectedNote?.ownerId !== user?.uid || sharedFolders.some(f => f.id === selectedNote?.folderId)}
                 onUpdate={(updated) => setSelectedNote(updated)}
                 className="h-full"
               />


### PR DESCRIPTION
### Description
This PR refactors the NoteEditor to use a robust Local-First architecture using Yjs.

**Changes:**
- Replaced the brittle 10s JSON polling override with `y-indexeddb` for instant, offline-first saving.
- Connected the existing `SocketIOProvider` to `y-websocket` principles when a note is in a shared mode.
- Completely removed manual DOM cursor manipulation and handed awareness state over to BlockNote for native, robust Figma-style collaborative cursors and text selection highlighting.
- Cleaned up dependency structures for CRDTs (`yjs`, `y-protocols`, `y-indexeddb`).