### PR TITLE
fix: Collaborative Editor real-time sync & presence highlighting

### DIFF
--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -275,6 +275,7 @@ const NoteEditorInner: React.FC<NoteEditorProps & { doc: Y.Doc, provider: any, i
                 editable={isEditable}
                 slashMenu={isEditable}
                 onChange={handleContentChange}
+                onSelectionChange={handleBlockFocus}
                 theme="dark"
                 className="ZYNC-editor-overrides"
               />

--- a/src/components/notes/NotesLayout.tsx
+++ b/src/components/notes/NotesLayout.tsx
@@ -799,7 +799,7 @@ export const NotesLayout: React.FC<NotesLayoutProps> = ({ user, users = [], init
                 key={selectedNote.id}
                 note={selectedNote}
                 user={{ uid: user.uid, displayName: user.displayName, email: user.email, photoURL: user.photoURL }}
-                isShared={selectedNote?.ownerId !== user?.uid || sharedFolders.some(f => f.id === selectedNote?.folderId)}
+                isShared={true}
                 onUpdate={(updated) => setSelectedNote(updated)}
                 className="h-full"
               />

--- a/src/lib/SocketIOProvider.ts
+++ b/src/lib/SocketIOProvider.ts
@@ -40,14 +40,14 @@ export class SocketIOProvider extends Observable<string> {
       setTimeout(() => {
         try {
           const stateUpdate = Y.encodeStateAsUpdate(this.doc);
-          this.socket.emit('note-update', { noteId, update: stateUpdate });
+          this.socket.emit('note-update', { noteId, update: Array.from(stateUpdate) });
         } catch (e) {
           console.error('[YJS Socket] Failed to send initial state', e);
         }
         
         if (this.awareness.clientID) {
           const awarenessUpdate = encodeAwarenessUpdate(this.awareness, [this.awareness.clientID]);
-          this.socket.emit('awareness-update', { noteId, update: awarenessUpdate });
+          this.socket.emit('awareness-update', { noteId, update: Array.from(awarenessUpdate) });
         }
       }, 500);
     });
@@ -64,10 +64,12 @@ export class SocketIOProvider extends Observable<string> {
         if (update instanceof ArrayBuffer) {
           uint8 = new Uint8Array(update);
         } else if (update && update.buffer instanceof ArrayBuffer) {
-          // It might already be a TypedArray or Buffer
           uint8 = new Uint8Array(update.buffer, update.byteOffset, update.byteLength);
+        } else if (Array.isArray(update)) {
+          uint8 = new Uint8Array(update);
+        } else if (typeof update === 'object' && update !== null) {
+          uint8 = new Uint8Array(Object.values(update));
         } else {
-          // Fallback if it's somehow an array or base64
           uint8 = new Uint8Array(update);
         }
         
@@ -79,7 +81,7 @@ export class SocketIOProvider extends Observable<string> {
 
     this.doc.on('update', (update: Uint8Array, origin: any) => {
       if (origin !== this && this.connected) {
-        this.socket.emit('note-update', { noteId, update });
+        this.socket.emit('note-update', { noteId, update: Array.from(update) });
       }
     });
 
@@ -90,6 +92,10 @@ export class SocketIOProvider extends Observable<string> {
           uint8 = new Uint8Array(update);
         } else if (update && update.buffer instanceof ArrayBuffer) {
           uint8 = new Uint8Array(update.buffer, update.byteOffset, update.byteLength);
+        } else if (Array.isArray(update)) {
+          uint8 = new Uint8Array(update);
+        } else if (typeof update === 'object' && update !== null) {
+          uint8 = new Uint8Array(Object.values(update));
         } else {
           uint8 = new Uint8Array(update);
         }
@@ -103,7 +109,7 @@ export class SocketIOProvider extends Observable<string> {
       if (origin !== this && this.connected) {
         const changedClients = added.concat(updated).concat(removed);
         const update = encodeAwarenessUpdate(this.awareness, changedClients);
-        this.socket.emit('awareness-update', { noteId, update });
+        this.socket.emit('awareness-update', { noteId, update: Array.from(update) });
       }
     });
   }


### PR DESCRIPTION
Hotfixes for the Yjs Collaborative Editor:
- Forces `isShared` to true for all notes to enable real-time sync for note owners across their own devices, preventing the owner from silently falling back to indexedDB offline mode.
- Patches `SocketIOProvider` to serialize ArrayBuffers as Arrays to prevent corruption if Socket.io falls back to HTTP polling.
- Hooks into BlockNote's `onSelectionChange` event so the collaborative border highlight fires immediately when a user clicks around, rather than only when typing.